### PR TITLE
please review this rhythmbox 2.7 change

### DIFF
--- a/StopAfterCurrentTrack/__init__.py
+++ b/StopAfterCurrentTrack/__init__.py
@@ -27,7 +27,7 @@ class StopAfterCurrentTrackPlugin (GObject.Object, Peas.Activatable):
         shell = self.object
         self.action = Gtk.ToggleAction(
                 name='StopAfterCurrentTrack',
-                label=('Stop After Current Track'),
+                label=('Stop After'),
                 tooltip=('Stop playback after current song'),
                 stock_id=Gtk.STOCK_MEDIA_STOP
                 )


### PR DESCRIPTION
The default view for rhythmbox 2.7 is show icons with text under the icon - by default this plugin name is too large resulting in a very large toolbar.

To fit with the new rb2.7 style, the plugin name needs to be reduced

Changes to be committed:

```
modified:   __init__.py
```
